### PR TITLE
Change propose method visibility

### DIFF
--- a/contracts/governance/GovernorUpgradeable.sol
+++ b/contracts/governance/GovernorUpgradeable.sol
@@ -256,7 +256,7 @@ abstract contract GovernorUpgradeable is Initializable, ContextUpgradeable, ERC1
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual override returns (uint256) {
+    ) internal virtual override returns (uint256) {
         address proposer = _msgSender();
 
         require(

--- a/contracts/governance/IGovernorUpgradeable.sol
+++ b/contracts/governance/IGovernorUpgradeable.sol
@@ -205,7 +205,7 @@ abstract contract IGovernorUpgradeable is Initializable, IERC165Upgradeable {
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual returns (uint256 proposalId);
+    ) internal virtual returns (uint256 proposalId);
 
     /**
      * @dev Execute a successful proposal. This requires the quorum to be reached, the vote to be successful, and the


### PR DESCRIPTION
Change propose method visibility from public to internal so that it is available to inherited contracts and not publicly. We need this change in order to implement some custom business logic related to making proposals.