### PR TITLE
Changing propose visibility in other contracts

### DIFF
--- a/contracts/governance/compatibility/GovernorCompatibilityBravoUpgradeable.sol
+++ b/contracts/governance/compatibility/GovernorCompatibilityBravoUpgradeable.sol
@@ -60,7 +60,7 @@ abstract contract GovernorCompatibilityBravoUpgradeable is Initializable, IGover
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual override(IGovernorUpgradeable, GovernorUpgradeable) returns (uint256) {
+    ) internal virtual override(IGovernorUpgradeable, GovernorUpgradeable) returns (uint256) {
         _storeProposal(_msgSender(), targets, values, new string[](calldatas.length), calldatas, description);
         return super.propose(targets, values, calldatas, description);
     }
@@ -74,7 +74,7 @@ abstract contract GovernorCompatibilityBravoUpgradeable is Initializable, IGover
         string[] memory signatures,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual override returns (uint256) {
+    ) internal virtual override returns (uint256) {
         _storeProposal(_msgSender(), targets, values, signatures, calldatas, description);
         return propose(targets, values, _encodeCalldata(signatures, calldatas), description);
     }

--- a/contracts/governance/compatibility/IGovernorCompatibilityBravoUpgradeable.sol
+++ b/contracts/governance/compatibility/IGovernorCompatibilityBravoUpgradeable.sol
@@ -84,7 +84,7 @@ abstract contract IGovernorCompatibilityBravoUpgradeable is Initializable, IGove
         string[] memory signatures,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual returns (uint256);
+    ) internal virtual returns (uint256);
 
     /**
      * @dev Part of the Governor Bravo's interface: _"Queues a proposal of state succeeded"_.

--- a/contracts/governance/extensions/GovernorProposalThresholdUpgradeable.sol
+++ b/contracts/governance/extensions/GovernorProposalThresholdUpgradeable.sol
@@ -23,7 +23,7 @@ abstract contract GovernorProposalThresholdUpgradeable is Initializable, Governo
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public virtual override returns (uint256) {
+    ) internal virtual override returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 

--- a/contracts/mocks/governance/GovernorCompatibilityBravoMockUpgradeable.sol
+++ b/contracts/mocks/governance/GovernorCompatibilityBravoMockUpgradeable.sol
@@ -50,7 +50,7 @@ abstract contract GovernorCompatibilityBravoMockUpgradeable is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public override(IGovernorUpgradeable, GovernorUpgradeable, GovernorCompatibilityBravoUpgradeable) returns (uint256) {
+    ) internal override(IGovernorUpgradeable, GovernorUpgradeable, GovernorCompatibilityBravoUpgradeable) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 

--- a/contracts/mocks/governance/GovernorMockUpgradeable.sol
+++ b/contracts/mocks/governance/GovernorMockUpgradeable.sol
@@ -28,7 +28,7 @@ abstract contract GovernorMockUpgradeable is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public override(GovernorUpgradeable, GovernorProposalThresholdUpgradeable) returns (uint256) {
+    ) internal override(GovernorUpgradeable, GovernorProposalThresholdUpgradeable) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 

--- a/contracts/mocks/wizard/MyGovernor1Upgradeable.sol
+++ b/contracts/mocks/wizard/MyGovernor1Upgradeable.sol
@@ -56,7 +56,7 @@ contract MyGovernor1Upgradeable is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public override(GovernorUpgradeable, IGovernorUpgradeable) returns (uint256) {
+    ) internal override(GovernorUpgradeable, IGovernorUpgradeable) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 

--- a/contracts/mocks/wizard/MyGovernor2Upgradeable.sol
+++ b/contracts/mocks/wizard/MyGovernor2Upgradeable.sol
@@ -62,7 +62,7 @@ contract MyGovernor2Upgradeable is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public override(GovernorUpgradeable, GovernorProposalThresholdUpgradeable, IGovernorUpgradeable) returns (uint256) {
+    ) internal override(GovernorUpgradeable, GovernorProposalThresholdUpgradeable, IGovernorUpgradeable) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 

--- a/contracts/mocks/wizard/MyGovernor3Upgradeable.sol
+++ b/contracts/mocks/wizard/MyGovernor3Upgradeable.sol
@@ -62,7 +62,7 @@ contract MyGovernorUpgradeable is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public override(GovernorUpgradeable, GovernorCompatibilityBravoUpgradeable, IGovernorUpgradeable) returns (uint256) {
+    ) internal override(GovernorUpgradeable, GovernorCompatibilityBravoUpgradeable, IGovernorUpgradeable) returns (uint256) {
         return super.propose(targets, values, calldatas, description);
     }
 


### PR DESCRIPTION
There are lots of other contracts that use GovernorUpgradeable or IGovernorUpgradeable so we need to update propose() visibility there too.